### PR TITLE
impl TokioCompatExt{Read,Write} for TcpStream

### DIFF
--- a/src/async_std/tokio_compat.rs
+++ b/src/async_std/tokio_compat.rs
@@ -74,3 +74,5 @@ impl<T: tokio::io::AsyncWrite + Unpin> Write for TokioCompat<T> {
 impl TokioCompatExt for TcpStream {}
 impl TokioCompatExtRead for ReadHalf<'_> {}
 impl TokioCompatExtWrite for WriteHalf<'_> {}
+impl TokioCompatExtRead for tokio::io::ReadHalf<TcpStream> {}
+impl TokioCompatExtWrite for tokio::io::WriteHalf<TcpStream> {}


### PR DESCRIPTION
This enables us to wrap tokio::io::ReadHalf and tokio::io::WriteHalf
in the Tokio compatibility layer. These are obtained when using
tokio::io::split instead of TcpStream::split, and have the advantage
that they take ownership of the underlying TcpStream instead of merely
borrowing it.