### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuska-handshake"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Dhole <dhole@riseup.net>", "Adria Massanet <adria@codecontext.io>"]
 edition = "2018"
 license-file = "LICENSE"


### PR DESCRIPTION
Bump version to include https://github.com/Kuska-ssb/handshake/pull/74 and https://github.com/Kuska-ssb/handshake/pull/75 to published version in crates.io