### PR TITLE
Derive `Clone` for `HandshakeComplete`

### DIFF
--- a/src/async_std/handshake.rs
+++ b/src/async_std/handshake.rs
@@ -33,20 +33,20 @@ pub async fn handshake_client<T: Read + Write + Unpin>(
     let handshake = Handshake::new_client(net_id, pk, sk);
 
     let mut send_buf = &mut buf[..handshake.send_bytes()];
-    let handshake = handshake.send_client_hello(&mut send_buf);
+    let handshake = handshake.send_client_hello(send_buf);
     stream.write_all(send_buf).await?;
 
     let mut recv_buf = &mut buf[..handshake.recv_bytes()];
-    stream.read_exact(&mut recv_buf).await?;
+    stream.read_exact(recv_buf).await?;
     let handshake = handshake.recv_server_hello(recv_buf)?;
 
     let mut send_buf = &mut buf[..handshake.send_bytes()];
-    let handshake = handshake.send_client_auth(&mut send_buf, server_pk)?;
+    let handshake = handshake.send_client_auth(send_buf, server_pk)?;
     stream.write_all(send_buf).await?;
 
     let mut recv_buf = &mut buf[..handshake.recv_bytes()];
-    stream.read_exact(&mut recv_buf).await?;
-    let handshake = handshake.recv_server_accept(&mut recv_buf)?;
+    stream.read_exact(recv_buf).await?;
+    let handshake = handshake.recv_server_accept(recv_buf)?;
 
     Ok(handshake.complete())
 }
@@ -61,19 +61,19 @@ pub async fn handshake_server<T: Read + Write + Unpin>(
     let handshake = Handshake::new_server(net_id, pk, sk);
 
     let mut recv_buf = &mut buf[..handshake.recv_bytes()];
-    stream.read_exact(&mut recv_buf).await?;
+    stream.read_exact(recv_buf).await?;
     let handshake = handshake.recv_client_hello(recv_buf)?;
 
     let mut send_buf = &mut buf[..handshake.send_bytes()];
-    let handshake = handshake.send_server_hello(&mut send_buf);
+    let handshake = handshake.send_server_hello(send_buf);
     stream.write_all(send_buf).await?;
 
     let mut recv_buf = &mut buf[..handshake.recv_bytes()];
-    stream.read_exact(&mut recv_buf).await?;
-    let handshake = handshake.recv_client_auth(&mut recv_buf)?;
+    stream.read_exact(recv_buf).await?;
+    let handshake = handshake.recv_client_auth(recv_buf)?;
 
     let mut send_buf = &mut buf[..handshake.send_bytes()];
-    let handshake = handshake.send_server_accept(&mut send_buf);
+    let handshake = handshake.send_server_accept(send_buf);
     stream.write_all(send_buf).await?;
 
     Ok(handshake.complete())

--- a/src/async_std/handshake.rs
+++ b/src/async_std/handshake.rs
@@ -32,19 +32,19 @@ pub async fn handshake_client<T: Read + Write + Unpin>(
     let mut buf = [0; 128];
     let handshake = Handshake::new_client(net_id, pk, sk);
 
-    let mut send_buf = &mut buf[..handshake.send_bytes()];
+    let send_buf = &mut buf[..handshake.send_bytes()];
     let handshake = handshake.send_client_hello(send_buf);
     stream.write_all(send_buf).await?;
 
-    let mut recv_buf = &mut buf[..handshake.recv_bytes()];
+    let recv_buf = &mut buf[..handshake.recv_bytes()];
     stream.read_exact(recv_buf).await?;
     let handshake = handshake.recv_server_hello(recv_buf)?;
 
-    let mut send_buf = &mut buf[..handshake.send_bytes()];
+    let send_buf = &mut buf[..handshake.send_bytes()];
     let handshake = handshake.send_client_auth(send_buf, server_pk)?;
     stream.write_all(send_buf).await?;
 
-    let mut recv_buf = &mut buf[..handshake.recv_bytes()];
+    let recv_buf = &mut buf[..handshake.recv_bytes()];
     stream.read_exact(recv_buf).await?;
     let handshake = handshake.recv_server_accept(recv_buf)?;
 
@@ -60,19 +60,19 @@ pub async fn handshake_server<T: Read + Write + Unpin>(
     let mut buf = [0; 128];
     let handshake = Handshake::new_server(net_id, pk, sk);
 
-    let mut recv_buf = &mut buf[..handshake.recv_bytes()];
+    let recv_buf = &mut buf[..handshake.recv_bytes()];
     stream.read_exact(recv_buf).await?;
     let handshake = handshake.recv_client_hello(recv_buf)?;
 
-    let mut send_buf = &mut buf[..handshake.send_bytes()];
+    let send_buf = &mut buf[..handshake.send_bytes()];
     let handshake = handshake.send_server_hello(send_buf);
     stream.write_all(send_buf).await?;
 
-    let mut recv_buf = &mut buf[..handshake.recv_bytes()];
+    let recv_buf = &mut buf[..handshake.recv_bytes()];
     stream.read_exact(recv_buf).await?;
     let handshake = handshake.recv_client_auth(recv_buf)?;
 
-    let mut send_buf = &mut buf[..handshake.send_bytes()];
+    let send_buf = &mut buf[..handshake.send_bytes()];
     let handshake = handshake.send_server_accept(send_buf);
     stream.write_all(send_buf).await?;
 

--- a/src/boxstream.rs
+++ b/src/boxstream.rs
@@ -386,6 +386,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(unused_must_use)]
     fn test_boxstream_error() {
         let test_error = |error| {
             format!("{}", error);

--- a/src/boxstream.rs
+++ b/src/boxstream.rs
@@ -144,12 +144,12 @@ impl Header {
 ///
 /// Note that the nonce is not incremented since this **must** be the last nonce used.
 fn encrypt_box_stream_goodbye(key_nonce: &mut KeyNonce, enc: &mut [u8]) -> usize {
-    let (goodbye_tag_buf, mut goodbye_header_buf) =
+    let (goodbye_tag_buf, goodbye_header_buf) =
         enc[..MSG_HEADER_LEN].split_at_mut(secretbox::MACBYTES);
     goodbye_header_buf.iter_mut().for_each(|x| *x = 0);
 
     let goodbye_tag =
-        secretbox::seal_detached(&mut goodbye_header_buf, &key_nonce.nonce, &key_nonce.key);
+        secretbox::seal_detached(goodbye_header_buf, &key_nonce.nonce, &key_nonce.key);
     goodbye_tag_buf.copy_from_slice(goodbye_tag.as_ref());
     MSG_HEADER_LEN
 }
@@ -164,17 +164,16 @@ fn encrypt_box_stream_msg(key_nonce: &mut KeyNonce, buf: &[u8], enc: &mut [u8]) 
     let body_nonce = key_nonce.nonce;
     key_nonce.increment_nonce_be_inplace();
 
-    let (header_buf, mut body_buf) =
-        enc[..MSG_HEADER_LEN + body.len()].split_at_mut(MSG_HEADER_LEN);
-    let (header_tag_buf, mut header_body_buf) = header_buf.split_at_mut(secretbox::MACBYTES);
+    let (header_buf, body_buf) = enc[..MSG_HEADER_LEN + body.len()].split_at_mut(MSG_HEADER_LEN);
+    let (header_tag_buf, header_body_buf) = header_buf.split_at_mut(secretbox::MACBYTES);
     body_buf.copy_from_slice(body);
-    let body_tag = secretbox::seal_detached(&mut body_buf, &body_nonce, &key_nonce.key);
+    let body_tag = secretbox::seal_detached(body_buf, &body_nonce, &key_nonce.key);
     let header = Header {
         body_len: body.len(),
         body_mac: body_tag,
     };
     header_body_buf.copy_from_slice(&header.to_bytes());
-    let header_tag = secretbox::seal_detached(&mut header_body_buf, &header_nonce, &key_nonce.key);
+    let header_tag = secretbox::seal_detached(header_body_buf, &header_nonce, &key_nonce.key);
     header_tag_buf.copy_from_slice(header_tag.as_ref());
     (body.len(), MSG_HEADER_LEN + body.len())
 }
@@ -196,14 +195,14 @@ impl BoxStreamSend {
     /// Encrypt a single boxstream message by taking bytes from `buf` and encrypting them into
     /// `enc`.  Returns the number of bytes read from `buf` and the number of bytes written into
     /// `enc`.
-    pub fn encrypt(&mut self, buf: &[u8], mut enc: &mut [u8]) -> Result<(usize, usize)> {
+    pub fn encrypt(&mut self, buf: &[u8], enc: &mut [u8]) -> Result<(usize, usize)> {
         if self.goodbye {
             return Err(Error::GoodbyeSent);
         }
         if buf.is_empty() {
             Ok((0, 0))
         } else {
-            Ok(encrypt_box_stream_msg(&mut self.key_nonce, buf, &mut enc))
+            Ok(encrypt_box_stream_msg(&mut self.key_nonce, buf, enc))
         }
     }
     /// Encrypt a goodbye message into `enc`.  Returns the number of bytes written into `enc`.
@@ -244,10 +243,9 @@ fn decrypt_box_stream_header(
     key_nonce: &mut KeyNonce,
     buf: &mut [u8],
 ) -> Result<Decrypted<Header>> {
-    let (header_tag_buf, mut header_body_buf) =
-        buf[..MSG_HEADER_LEN].split_at_mut(secretbox::MACBYTES);
+    let (header_tag_buf, header_body_buf) = buf[..MSG_HEADER_LEN].split_at_mut(secretbox::MACBYTES);
     match secretbox::open_detached(
-        &mut header_body_buf,
+        header_body_buf,
         &secretbox::Tag::from_slice(header_tag_buf).unwrap(),
         &key_nonce.nonce,
         &key_nonce.key,
@@ -273,13 +271,8 @@ fn decrypt_box_stream_body(
     key_nonce: &mut KeyNonce,
     buf: &mut [u8],
 ) -> Result<usize> {
-    let mut body_buf = &mut buf[..header.body_len];
-    match secretbox::open_detached(
-        &mut body_buf,
-        &header.body_mac,
-        &key_nonce.nonce,
-        &key_nonce.key,
-    ) {
+    let body_buf = &mut buf[..header.body_len];
+    match secretbox::open_detached(body_buf, &header.body_mac, &key_nonce.nonce, &key_nonce.key) {
         Ok(()) => {
             key_nonce.increment_nonce_be_inplace();
             Ok(header.body_len)

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -556,7 +556,7 @@ impl Handshake<SendServerAccept> {
 
 /// Type used to group all the values obtained during a successful handshake that can be used to
 /// stablish a secure authenticated channel.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HandshakeComplete {
     pub net_id: auth::Key,
     pub pk: ed25519::PublicKey,

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -313,9 +313,9 @@ impl Handshake<SendClientAuth> {
 
 impl Handshake<RecvServerAccept> {
     pub fn recv_server_accept(self, recv_buf: &mut [u8]) -> Result<Handshake<Complete>> {
-        let (tag_buf, mut enc_buf) = recv_buf.split_at_mut(secretbox::MACBYTES);
+        let (tag_buf, enc_buf) = recv_buf.split_at_mut(secretbox::MACBYTES);
         secretbox::open_detached(
-            &mut enc_buf,
+            enc_buf,
             &secretbox::Tag::from_slice(tag_buf).unwrap(),
             &secretbox::Nonce([0; 24]),
             &secretbox::Key(
@@ -447,9 +447,9 @@ impl Handshake<SendServerHello> {
 impl Handshake<RecvClientAuth> {
     /// Receive a client auth and advance to the next server state.
     pub fn recv_client_auth(self, recv_buf: &mut [u8]) -> Result<Handshake<SendServerAccept>> {
-        let (tag_buf, mut enc_buf) = recv_buf.split_at_mut(secretbox::MACBYTES);
+        let (tag_buf, enc_buf) = recv_buf.split_at_mut(secretbox::MACBYTES);
         secretbox::open_detached(
-            &mut enc_buf,
+            enc_buf,
             &secretbox::Tag::from_slice(tag_buf).unwrap(),
             &secretbox::Nonce([0; 24]),
             &secretbox::Key(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,9 @@ pub mod async_std;
 mod boxstream;
 mod handshake;
 
-pub use boxstream::*;
-pub use handshake::*;
+pub use boxstream::{
+    BoxStreamRecv, BoxStreamSend, Error as BoxstreamError, Header, Result as BoxstreamResult,
+};
+pub use handshake::{
+    Error as HandshakeError, Handshake, Result as HandshakeResult, SendServerAccept,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,9 @@ mod boxstream;
 mod handshake;
 
 pub use boxstream::{
-    BoxStreamRecv, BoxStreamSend, Error as BoxstreamError, Header, Result as BoxstreamResult,
+    BoxStreamRecv, BoxStreamSend, Error as BoxstreamError, Header, KeyNonce,
+    Result as BoxstreamResult,
 };
 pub use handshake::{
-    Error as HandshakeError, Handshake, Result as HandshakeResult, SendServerAccept,
+    Error as HandshakeError, Handshake, Result as HandshakeResult, SendServerAccept, SharedSecret,
 };

--- a/src/sync/handshake.rs
+++ b/src/sync/handshake.rs
@@ -32,20 +32,20 @@ pub fn handshake_client<T: Read + Write>(
     let handshake = Handshake::new_client(net_id, pk, sk);
 
     let mut send_buf = &mut buf[..handshake.send_bytes()];
-    let handshake = handshake.send_client_hello(&mut send_buf);
+    let handshake = handshake.send_client_hello(send_buf);
     stream.write_all(send_buf)?;
 
     let mut recv_buf = &mut buf[..handshake.recv_bytes()];
-    stream.read_exact(&mut recv_buf)?;
+    stream.read_exact(recv_buf)?;
     let handshake = handshake.recv_server_hello(recv_buf)?;
 
     let mut send_buf = &mut buf[..handshake.send_bytes()];
-    let handshake = handshake.send_client_auth(&mut send_buf, server_pk)?;
+    let handshake = handshake.send_client_auth(send_buf, server_pk)?;
     stream.write_all(send_buf)?;
 
     let mut recv_buf = &mut buf[..handshake.recv_bytes()];
-    stream.read_exact(&mut recv_buf)?;
-    let handshake = handshake.recv_server_accept(&mut recv_buf)?;
+    stream.read_exact(recv_buf)?;
+    let handshake = handshake.recv_server_accept(recv_buf)?;
 
     Ok(handshake.complete())
 }
@@ -60,19 +60,19 @@ pub fn handshake_server<T: Read + Write>(
     let handshake = Handshake::new_server(net_id, pk, sk);
 
     let mut recv_buf = &mut buf[..handshake.recv_bytes()];
-    stream.read_exact(&mut recv_buf)?;
+    stream.read_exact(recv_buf)?;
     let handshake = handshake.recv_client_hello(recv_buf)?;
 
     let mut send_buf = &mut buf[..handshake.send_bytes()];
-    let handshake = handshake.send_server_hello(&mut send_buf);
+    let handshake = handshake.send_server_hello(send_buf);
     stream.write_all(send_buf)?;
 
     let mut recv_buf = &mut buf[..handshake.recv_bytes()];
-    stream.read_exact(&mut recv_buf)?;
-    let handshake = handshake.recv_client_auth(&mut recv_buf)?;
+    stream.read_exact(recv_buf)?;
+    let handshake = handshake.recv_client_auth(recv_buf)?;
 
     let mut send_buf = &mut buf[..handshake.send_bytes()];
-    let handshake = handshake.send_server_accept(&mut send_buf);
+    let handshake = handshake.send_server_accept(send_buf);
     stream.write_all(send_buf)?;
 
     Ok(handshake.complete())

--- a/src/sync/handshake.rs
+++ b/src/sync/handshake.rs
@@ -31,19 +31,19 @@ pub fn handshake_client<T: Read + Write>(
     let mut buf = [0; 128];
     let handshake = Handshake::new_client(net_id, pk, sk);
 
-    let mut send_buf = &mut buf[..handshake.send_bytes()];
+    let send_buf = &mut buf[..handshake.send_bytes()];
     let handshake = handshake.send_client_hello(send_buf);
     stream.write_all(send_buf)?;
 
-    let mut recv_buf = &mut buf[..handshake.recv_bytes()];
+    let recv_buf = &mut buf[..handshake.recv_bytes()];
     stream.read_exact(recv_buf)?;
     let handshake = handshake.recv_server_hello(recv_buf)?;
 
-    let mut send_buf = &mut buf[..handshake.send_bytes()];
+    let send_buf = &mut buf[..handshake.send_bytes()];
     let handshake = handshake.send_client_auth(send_buf, server_pk)?;
     stream.write_all(send_buf)?;
 
-    let mut recv_buf = &mut buf[..handshake.recv_bytes()];
+    let recv_buf = &mut buf[..handshake.recv_bytes()];
     stream.read_exact(recv_buf)?;
     let handshake = handshake.recv_server_accept(recv_buf)?;
 
@@ -59,19 +59,19 @@ pub fn handshake_server<T: Read + Write>(
     let mut buf = [0; 128];
     let handshake = Handshake::new_server(net_id, pk, sk);
 
-    let mut recv_buf = &mut buf[..handshake.recv_bytes()];
+    let recv_buf = &mut buf[..handshake.recv_bytes()];
     stream.read_exact(recv_buf)?;
     let handshake = handshake.recv_client_hello(recv_buf)?;
 
-    let mut send_buf = &mut buf[..handshake.send_bytes()];
+    let send_buf = &mut buf[..handshake.send_bytes()];
     let handshake = handshake.send_server_hello(send_buf);
     stream.write_all(send_buf)?;
 
-    let mut recv_buf = &mut buf[..handshake.recv_bytes()];
+    let recv_buf = &mut buf[..handshake.recv_bytes()];
     stream.read_exact(recv_buf)?;
     let handshake = handshake.recv_client_auth(recv_buf)?;
 
-    let mut send_buf = &mut buf[..handshake.send_bytes()];
+    let send_buf = &mut buf[..handshake.send_bytes()];
     let handshake = handshake.send_server_accept(send_buf);
     stream.write_all(send_buf)?;
 


### PR DESCRIPTION
Simply derives `Clone` for the `HandshakeComplete` `struct` and addresses clippy lints related to needless borrows.

@adria0, would you be able to merge this? I don't have write permissions for the handshake repo.